### PR TITLE
Detect when base text is used for other languages

### DIFF
--- a/Sources/LocheckLogic/Problems.swift
+++ b/Sources/LocheckLogic/Problems.swift
@@ -82,6 +82,18 @@ struct KeyMissingFromTranslation: Problem, StringsProblem, Equatable {
     var message: String { "'\(key)' is missing from \(language)" }
 }
 
+struct TranslationSameAsBase: Problem, StringsProblem, Equatable {
+    var kindIdentifier: String { "translation_same_as_base" }
+    var uniquifyingInformation: String { "\(language)-\(key)" }
+    var severity: Severity { .warning }
+    var base: String? { nil }
+    var translation: String? { nil }
+    let key: String
+    let language: String
+
+    var message: String { "'\(key)' is same as \(language)" }
+}
+
 struct LprojFileMissingFromTranslation: Problem, Equatable {
     var kindIdentifier: String { "lproj_file_missing_from_translation" }
     var uniquifyingInformation: String { "\(language)-\(key)" }

--- a/Sources/LocheckLogic/Validators/parseAndValidateXCStrings.swift
+++ b/Sources/LocheckLogic/Validators/parseAndValidateXCStrings.swift
@@ -64,6 +64,15 @@ func validateStrings(
             lineNumber: baseString.line)
     }
 
+    for baseString in baseStrings where translationStringMap[baseString.key]?.translation.string == baseString.translation.string {
+        problemReporter.report(
+            TranslationSameAsBase(
+                key: baseString.key,
+                language: translationLanguageName),
+            path: baseString.path,
+            lineNumber: baseString.line)
+    }
+
     // MARK: Validate arguments
 
     for translationString in translationStrings {


### PR DESCRIPTION
Thanks for this great tool, I have an improvement suggestion but not sure if it would be useful for everyone:
a common case is when developers is waiting for translation is to put the English (base) text for other languages and forget about it.

Cheers !
